### PR TITLE
:bug: `basic-auth-pasword` variable was added inline

### DIFF
--- a/bmrg-auth-proxy/templates/deployment.yaml
+++ b/bmrg-auth-proxy/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- if .Values.auth.args -}}
         {{- .Values.auth.args | toYaml | nindent 8 -}}
         {{- end -}}
-        {{- if $.Values.auth.displayHtpasswdForm -}}
+        {{- if $.Values.auth.displayHtpasswdForm }}
         - --basic-auth-password=$(UPSTREAM_AUTH_PASSWORD)
         {{- end }}
         {{- if $.Values.redis.enabled }}


### PR DESCRIPTION
Closes #

[bmrg-auth-proxy] Authentication fails when using basic-auth mode #3

#### Changelog

**New**

- N/A

**Changed**

- N/A

**Removed**

- Removed the early closure for [basic-auth-password statement](https://github.com/boomerang-io/charts/blob/main/bmrg-auth-proxy/templates/deployment.yaml#L31).
<img width="583" alt="image" src="https://user-images.githubusercontent.com/67386493/89418248-7a680800-d738-11ea-8d97-985db397a45a.png">


#### Testing / Reviewing

```sh
helm3 install <release-name> --namespace <auth-namespace> <helm repo / chart package> --set auth.displayHtpasswdForm=true --dry-run
```

`basic-auth-password` value should be on its own line:

```yaml
spec:
  ...
  template:
    ...
    spec:
      containers:
      - args:
        ...
        - --pass-basic-auth=true
        - --basic-auth-password=$(UPSTREAM_AUTH_PASSWORD)
        - --email-domain=*
```
