### PR TITLE
Basic auth configuration fix

### DIFF
--- a/bmrg-auth-proxy/Chart.yaml
+++ b/bmrg-auth-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bmrg-auth-proxy
 description: Boomerang Auth Reverse Proxy for integrating to authentication providers
-version: 3.1.10
+version: 3.1.11
 type: application
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-auth-proxy/README.md
+++ b/bmrg-auth-proxy/README.md
@@ -99,7 +99,7 @@ Important arguments are:
 1. Set the `display-htpasswd-form` to activate the auth-basic form.
 2. The `htpasswd-file` is the path to the file that contains the usernames and passwords from within the container
 3. The `basic-auth-password` is to be set to the cookie-secret in order for the up-stream systems to receive the Authorization header in the format of username:password
-4. The `pass-basic-auth` must be set to `true` in order for the Authorization header to be passed to the up-stream systems
+4. The `pass-basic-auth` and `set-basic-auth` must be set to `true` in order for the Authorization header to be passed to the up-stream systems
 5. The rest of the arguments are well known and they don't need to be explained
 
 ```yaml
@@ -117,6 +117,7 @@ auth:
     - --htpasswd-file=/opt/config/htpasswd
     - --cookie-refresh=0
     - --pass-basic-auth=true
+    - --set-basic-auth=true
     - --basic-auth-password=<<password_to_be_sent_to_upstreams>>
   displayHtpasswdForm: true
   provider:


### PR DESCRIPTION
Closes #8 

Updating the README documentation to set the `set-basic-auth` to true for basic auth configuration.

#### Changelog

**New**

- NA

**Changed**

- Updated the documentation on the basic-auth configuration

**Removed**

- NA

#### Testing / Reviewing

Did the testing in our ICP cluster, in the poc environment.
