### PR TITLE
:bug:Updated image configuration to v6.0.x

### DIFF
--- a/bmrg-auth-proxy/Chart.yaml
+++ b/bmrg-auth-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bmrg-auth-proxy
 description: Boomerang Auth Reverse Proxy for integrating to authentication providers
-version: 3.1.10
+version: 3.2.1
 type: application
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-auth-proxy/values.yaml
+++ b/bmrg-auth-proxy/values.yaml
@@ -36,6 +36,7 @@ auth:
     - --whitelist-domain=
     # pass -pass-basic-auth for basic-auth mechanism
     - --pass-basic-auth=true
+    - --user-id-claim=emailAddress
 
 image:
   registry: boomerangio


### PR DESCRIPTION
Closes #10 

Starting with v6.0.x of the auth-proxy docker image, the email claim name is now configurable, part of the `user-id-claim` param.

#### Changelog

**New**

- Introduced a new arg entry, `user-id-claim`

**Changed**

**Removed**

#### Testing / Reviewing

Tested in our local environments.
