### PR TITLE
Introducing multi Jaeger deployment support

### DIFF
--- a/bmrg-common/Chart.yaml
+++ b/bmrg-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-common
 description: Common helpers for Boomerang charts
 type: library
-version: 1.0.2
+version: 1.0.3
 home: https://useboomerang.io
 keywords:
 - boomerang

--- a/bmrg-common/README.md
+++ b/bmrg-common/README.md
@@ -5,6 +5,7 @@ This is the common helper chart as a sharable library of helper templates which 
 ### New in this release
 
 1. The `bmrg.core.services` helper now prefixes generated items with `core.` i.e. `auth.service.host` now becomes `core.auth.service.host`.
+2. The common helpers offers multi Jaeger agent configuration deployment.
 
 ## Prerequisites
 

--- a/bmrg-common/templates/_boomerang.tpl
+++ b/bmrg-common/templates/_boomerang.tpl
@@ -167,21 +167,106 @@ access_by_lua_block {
 {{- end -}}
 
 {{/*
-Chart resources to insert in the pod definition.  This works by being fed a dictionary of Values plus the item for which it generates the resource request/limits. 
+Chart resources to insert in the pod definition.  This works by being fed a dictionary of Values plus the item for which it generates the resource request/limits.
 Example Usage: {{- include "bmrg.resources.chart" (dict "context" $.Values "item" $v "tier" $tier ) | nindent 10 }}
 */}}
 {{- define "bmrg.resources.chart" -}}
 {{- if .item.resources }}
 {{- with .item.resources }}
-resources: 
+resources:
 {{ toYaml . | trim | indent 2 }}
 {{- end }}
 {{- else if .context.resources }}
 {{- if hasKey .context.resources .tier }}
 {{- with .context.resources.services }}
-resources: 
+resources:
 {{ toYaml . | trim | indent 2 }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Insert the Jaeger agents deployed as side-cars to the app cntr
+Example Usage: {{- include "bmrg.jaeger.deployment.agents" (dict "context" $.Values) | nindent 8 }}
+*/}}
+{{- define "bmrg.jaeger.deployment.agents" -}}
+{{- if .context.Values.monitoring.jaeger.enabled }}
+{{- range $kj, $vj := .context.Values.monitoring.jaeger.instances }}
+{{- if ne $vj.name "operational" }}
+- name: "jaeger-agent-{{ $vj.name }}-cntr"
+  image: "{{ $vj.agent.image.repository }}:{{ $vj.agent.image.tag }}"
+  args: ["--reporter.grpc.host-port={{ $vj.collector.host }}.{{ $vj.namespace }}.svc:14250"]
+  ports:
+  - containerPort: 5775
+    protocol: UDP
+  - containerPort: 6831
+    protocol: UDP
+  - containerPort: 6832
+    protocol: UDP
+  - containerPort: 5778
+    protocol: TCP
+  - containerPort: 14271
+    name: admin
+    protocol: TCP
+  livenessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /
+      port: admin
+      scheme: HTTP
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  readinessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /
+      port: admin
+      scheme: HTTP
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+{{- if $vj.agent.resources }}
+{{- with $vj.agent.resources }}
+  resources:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+{{- else }}
+  resources:
+    limits:
+      cpu: 20m
+      memory: 20Mi
+    requests:
+      cpu: 10m
+      memory: 10Mi
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the application.properties entries for the multiple agents, backward compatible
+Example Usage: {{- include "bmrg.jaeger.config.agents" (dict "context" $) | nindent 4 }}
+*/}}
+{{- define "bmrg.jaeger.config.agents" }}
+opentracing.jaeger.enabled={{ .Values.monitoring.jaeger.enabled }}
+opentracing.jaeger.remote-controlled-sampler.host-port={{ .Values.monitoring.jaeger.remoteControlledSampler.host }}:{{ .Values.monitoring.jaeger.remoteControlledSampler.port }}
+opentracing.jaeger.sampler-type=remote
+opentracing.jaeger.sampler-param=1
+{{- if .Values.monitoring.jaeger.instances }}
+{{- range $index, $v := .Values.monitoring.jaeger.instances }}
+opentracing.jaeger.instance.[{{ $index }}].http-sender.enabled={{ if eq $v.name "operational" }}false{{ else }}true{{ end }}
+opentracing.jaeger.instance.[{{ $index }}].udp-sender.host={{ $v.agent.host }}
+opentracing.jaeger.instance.[{{ $index }}].udp-sender.port={{ $v.agent.port }}
+opentracing.jaeger.instance.[{{ $index }}].http-sender.url=http://{{ $v.collector.host }}.{{ $v.namespace }}:{{ $v.collector.port }}/api/traces
+{{- end }}
+{{- else }}
+# backward compatible jaeger reporters definition
+opentracing.jaeger.instance.[0].http-sender.enabled=true
+opentracing.jaeger.instance.[0].udp-sender.host={{ .Values.monitoring.jaeger.agent.host }}.{{ .Values.monitoring.jaeger.namespace }}
+opentracing.jaeger.instance.[0].udp-sender.port={{ .Values.monitoring.jaeger.agent.port }}
+opentracing.jaeger.instance.[0].http-sender.url=http://{{ .Values.monitoring.jaeger.collector.host }}.{{ .Values.monitoring.jaeger.namespace }}:{{ .Values.monitoring.jaeger.collector.port }}/api/traces
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Closes #12 

Introducing two common functions:
1/ `bmrg.jaeger.config.agents` to be used in the configmap resources in order to generate the configuration in the application.properties necessary for the java jaeger framework,
2/ `bmrg.jaeger.deployment.agents` to ber used in the deployment resources to generate the list of Jaeger agents as side-cars to the business container.

#### Changelog

**New**

- Introducing `bmrg.jaeger.config.agents` and `bmrg.jaeger.deployment.agents`.

**Changed**

- NA

**Removed**

- NA

#### Testing / Reviewing

Tested on the local env.
