### PR TITLE
feat: add metering service support to  helper

### DIFF
--- a/bmrg-common/Chart.yaml
+++ b/bmrg-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-common
 description: Common helpers for Boomerang charts
 type: library
-version: 1.0.2
+version: 1.0.3
 home: https://useboomerang.io
 keywords:
 - boomerang

--- a/bmrg-common/README.md
+++ b/bmrg-common/README.md
@@ -4,7 +4,7 @@ This is the common helper chart as a sharable library of helper templates which 
 
 ### New in this release
 
-1. The `bmrg.core.services` helper now prefixes generated items with `core.` i.e. `auth.service.host` now becomes `core.auth.service.host`.
+1. The `bmrg.core.services` helper now supports also the metering service.
 
 ## Prerequisites
 

--- a/bmrg-common/templates/_boomerang.tpl
+++ b/bmrg-common/templates/_boomerang.tpl
@@ -83,13 +83,13 @@ Insert the core services
 {{- if hasKey .Values "core" }}
 {{- $prefix := .Values.core.namePrefix -}}
 {{- $namespace := .Values.core.namespace -}}
-{{- range (list "admin" "audit" "auth" "launchpad" "messaging" "slack" "mail" "notifications" "settings" "status" "support" "users" ) }}
+{{- range (list "admin" "audit" "auth" "launchpad" "messaging" "slack" "mail" "notifications" "settings" "status" "support" "users" "metering" ) }}
 core.{{ . }}.service.host={{ $prefix }}-services-{{ . }}{{ if $namespace }}.{{ $namespace }}{{ end }}
 {{- end -}}
 {{- else -}}
 {{- $prefix := .Values.boomerang.core.namePrefix -}}
 {{- $namespace := .Values.boomerang.core.namespace -}}
-{{- range (list "admin" "audit" "auth" "launchpad" "messaging" "slack" "mail" "notifications" "settings" "status" "support" "users" ) }}
+{{- range (list "admin" "audit" "auth" "launchpad" "messaging" "slack" "mail" "notifications" "settings" "status" "support" "users" "metering" ) }}
 core.{{ . }}.service.host={{ $prefix }}-services-{{ . }}{{ if $namespace }}.{{ $namespace }}{{ end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Closes #14 

Added support for the `metering` service for easier integration with the metering framework and to maintain consistency with the rest of the core services.

#### Changelog

**New**

- N/A

**Changed**

- added the `metering` option to the `bmrg.core.services` helper

**Removed**

- N/A

#### Testing / Reviewing

When importing the `bmrg.core.services` helper, the output should also contain the property `core.metering.service.host`.
