### PR TITLE
Introduced helper functions for nodeSelector, affinity and …

### DIFF
--- a/bmrg-auth-proxy/Chart.yaml
+++ b/bmrg-auth-proxy/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: bmrg-auth-proxy
 description: Boomerang Auth Reverse Proxy for integrating to authentication providers
-version: 3.2.1
+version: 3.2.2
 type: application
 home: https://useboomerang.io
 dependencies:
   - name: bmrg-common
     repository: https://raw.githubusercontent.com/boomerang-io/charts/index
-    version: ~1.0.0
+    version: ~1.0.4
     alias: bmrgcommon
   - name: redis
     version: 10.6.0

--- a/bmrg-auth-proxy/templates/deployment.yaml
+++ b/bmrg-auth-proxy/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         name: {{ .Chart.Name }}
         {{- if $.Values.auth.displayHtpasswdForm }}
-        env: 
+        env:
         - name: UPSTREAM_AUTH_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -116,7 +116,7 @@ spec:
         - name: saml-volume
           configMap:
             name: {{ include "bmrg.name" (dict "context" $ "component" "config" "tier" "saml") }}
-            items: 
+            items:
               - key: saml_sp.cert
                 path: saml_sp.cert
               - key: saml_sp.key
@@ -128,15 +128,6 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+    {{- include "bmrg.config.node_selector" $ }}
+    {{- include "bmrg.config.affinity" $ }}
+    {{- include "bmrg.config.tolerations" $ }}

--- a/bmrg-common/Chart.yaml
+++ b/bmrg-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-common
 description: Common helpers for Boomerang charts
 type: library
-version: 1.0.2
+version: 1.0.4
 home: https://useboomerang.io
 keywords:
 - boomerang

--- a/bmrg-common/templates/_boomerang.tpl
+++ b/bmrg-common/templates/_boomerang.tpl
@@ -167,21 +167,54 @@ access_by_lua_block {
 {{- end -}}
 
 {{/*
-Chart resources to insert in the pod definition.  This works by being fed a dictionary of Values plus the item for which it generates the resource request/limits. 
+Chart resources to insert in the pod definition.  This works by being fed a dictionary of Values plus the item for which it generates the resource request/limits.
 Example Usage: {{- include "bmrg.resources.chart" (dict "context" $.Values "item" $v "tier" $tier ) | nindent 10 }}
 */}}
 {{- define "bmrg.resources.chart" -}}
 {{- if .item.resources }}
 {{- with .item.resources }}
-resources: 
+resources:
 {{ toYaml . | trim | indent 2 }}
 {{- end }}
 {{- else if .context.resources }}
 {{- if hasKey .context.resources .tier }}
 {{- with .context.resources.services }}
-resources: 
+resources:
 {{ toYaml . | trim | indent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Define the helper method to define the nodeSelector .
+Example Usage: {{- include "bmrg.config.node_selector" $ }}
+*/}}
+{{- define "bmrg.config.node_selector" -}}
+    {{- with $.Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Define the helper method to define the affinity .
+Example Usage: {{- include "bmrg.config.affinity" $ }}
+*/}}
+{{- define "bmrg.config.affinity" -}}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Define the helper method to define the tolerations .
+Example Usage: {{- include "bmrg.config.tolerations" $ }}
+*/}}
+{{- define "bmrg.config.tolerations" -}}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- end -}}


### PR DESCRIPTION
Introduced helper functions for nodeSelector, affinity and tolerations.

Closes #12 

#### Changelog

**New**

- Defined new common helpers: bmrg.config.node_selector, bmrg.config.affinity and bmrg.config.tolerations.

**Changed**

- Update the bmrg-auth-proxy to use the new functions as an example.

**Removed**

- NA

#### Testing / Reviewing

Tested in the poc environment.
