### PR TITLE
bump up chart and image tag versions

### DIFF
--- a/bmrg-auth-proxy/Chart.yaml
+++ b/bmrg-auth-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bmrg-auth-proxy
 description: Boomerang Auth Reverse Proxy for integrating to authentication providers
-version: 3.3.1
+version: 3.3.2
 type: application
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-auth-proxy/values.yaml
+++ b/bmrg-auth-proxy/values.yaml
@@ -48,7 +48,7 @@ services:
   authProxy:
     image:
       repository: /oauth2-proxy
-      tag: 5.1.0-bmrg.2
+      tag: 6.1.1-bmrg.3
 #  authProxy:
 #    image:
 #      repository: /bmrg-saml-proxy


### PR DESCRIPTION
Closes #

Increment chart version and default auth-proxy image tag

#### Changelog

**New**

- N/A

**Changed**

- Chart version from `3.3.1` to `3.3.2`
- Default auth-proxy image tag from `5.1.0-bmrg.2` to `6.1.1-bmrg.3`

**Removed**

- N/A

#### Testing / Reviewing

N/A
