### PR TITLE
add nats.url and nats.cluster only if nats is enabled

### DIFF
--- a/bmrg-flow/templates/configmap.yaml
+++ b/bmrg-flow/templates/configmap.yaml
@@ -23,8 +23,10 @@ data:
     {{- end }}
     {{- include "bmrg.core.services" $ | indent 4 }}
     eventing.nats.enabled={{ $values.nats.enable }}
+    {{- if $.Values.nats.enable }}
     eventing.nats.url={{ $values.nats.url }}
     eventing.nats.cluster={{ $values.nats.cluster }}
+    {{- end }}
     {{- if $.Values.general.enable.debug }}
     logging.level.org.springframework.web.client.RestTemplate=DEBUG
     logging.level.org.springframework.core.env.PropertySourcesPropertyResolver=DEBUG


### PR DESCRIPTION
Closes #

`nats.url` and `nats.cluster` could not be ommited if `nats.enable` was set to false

#### Changelog

**New**

- N/A

**Changed**

- Added a contitional statement for `nats.url` and `nats.cluster` based on `nats.enable`

**Removed**

- N/A

#### Testing / Reviewing

N/A
