### PR TITLE
Updating the bmrg-common dep to the version that introduced the globa…

### DIFF
--- a/bmrg-bosun/Chart.yaml
+++ b/bmrg-bosun/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: bmrg-bosun
 description: Boomerang Bosun
 type: application
-version: 2.2.0
+version: 2.2.1
 appVersion: "1.0.2"
 home: https://useboomerang.io
 dependencies:
   - name: bmrg-common
     repository: https://raw.githubusercontent.com/boomerang-io/charts/index
-    version: 2.0.7
+    version: ~3.0.1
     alias: ch
 keywords:
 - boomerang


### PR DESCRIPTION
Updating the `bmrg-common` dependency  to the 3.0.1 version that introduced the global section in the values.

Closes #

In order for the chart to create the ingress prefix and the auth-signin paths it needs to use the 3.0.1 version of bmrg-common that fixed this issue.

#### Changelog

**New**

- NA

**Changed**

- Updated the dependency on the bmrg-common

**Removed**

- NA

#### Testing / Reviewing

Tested on the bosun public instance.
