### PR TITLE
Deprecating the auth2-proxy helm chart in favour of the OSS hosted one

### DIFF
--- a/bmrg-auth-proxy/Chart.yaml
+++ b/bmrg-auth-proxy/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 name: bmrg-auth-proxy
 description: Boomerang Auth Reverse Proxy for integrating to authentication providers
-version: 3.3.2
+version: 3.3.3
 type: application
 home: https://useboomerang.io
+deprecated: true
 dependencies:
   - name: bmrg-common
     repository: https://raw.githubusercontent.com/boomerang-io/charts/index

--- a/bmrg-auth-proxy/README.md
+++ b/bmrg-auth-proxy/README.md
@@ -8,6 +8,11 @@ Boomerang Auth Reverse Proxy, forked from [oauth2-proxy](https://github.com/oaut
  - [Azure Active Directory](#integrating-with-azure-aD-provider) and
  - [SAML](#integrating-with-sAML-based-providers) based providers.
 
+## Deprecated
+
+This chart is deprecated in favour of **OAuth2-Proxy**'s Official Helm Chart.
+See https://github.com/oauth2-proxy/manifests for installation instructions.
+
 ### New in this release
 
 1. IBM OIDC provider


### PR DESCRIPTION
Closes #

Since all the necessary changes were pushed and merged in the **OAuth2-Proxy**'s Official Helm Chart, located https://github.com/oauth2-proxy/manifests , we are deprecating the bmrg-auth-proxy helm chart.

#### Changelog

**New**

- NA

**Changed**

- NA

**Removed**

- Deprecating the bmrg-auth-proxy helm chart

#### Testing / Reviewing

The **OAuth2-Proxy**'s Official Helm Chart was tested in our PoC and dev environments.