### PR TITLE
Introduced a new utility method 

### DIFF
--- a/bmrg-common/Chart.yaml
+++ b/bmrg-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-common
 description: Common helpers for Boomerang charts
 type: library
-version: 3.0.1
+version: 3.0.2
 home: https://useboomerang.io
 keywords:
 - boomerang

--- a/bmrg-common/README.md
+++ b/bmrg-common/README.md
@@ -43,6 +43,7 @@ The following table lists the helper methods of the `bmrg-common` chart and thei
 | `bmrg.util.time` | Uses the `$.Release.Time` global variable and removes certain string content | `{{ include "bmrg.util.time" }`
 | `bmrg.util.joinListWithNL` | Create a string from joining a list with new line. | `{{ include "bmrg.util.joinListWithNL" .Values.authorization.allowEmailList.emailList | b64enc }}`
 | `bmrg.ingress.config.auth_proxy_authorization` | Inserts nginx configuration snippet to set the Authorization header | `{{- include "bmrg.ingress.config.auth_proxy_access_control" $ | nindent 6 }}`
+| `bmrg.ingress.config.auth_proxy_user_email` | Inserts nginx configuration snippet to set the X-Forwarded-User and X-Forwarded-Email headers | `{{- include "bmrg.ingress.config.auth_proxy_user_email" $ | nindent 6 }}`
 | `bmrg.ingress.config.auth_proxy_access_control` | Inserts nginx configuration snippet for Access Control for auth proxy. | `{{- include "bmrg.ingress.config.auth_proxy_access_control" $ | nindent 6 }}`
 | `bmrg.ingress.config.auth_proxy_auth_annotations` | Inserts nginx auth-url, auth-signin and auth-response-headers ingress annotations. These rely on `auth.*` from the values yaml. | `{{- include "bmrg.ingress.config.auth_proxy_auth_annotations" $ | nindent 4 }}`
 | `bmrg.ingress.config.auth_proxy_auth_annotations.global` | Inserts nginx auth-url, auth-signin and auth-response-headers ingress annotations. These rely on `global.auth.*` from the values yaml. | `{{- include "bmrg.ingress.config.auth_proxy_auth_annotations.global" $ | nindent 4 }}`

--- a/bmrg-common/templates/_boomerang.tpl
+++ b/bmrg-common/templates/_boomerang.tpl
@@ -129,6 +129,16 @@ proxy_set_header Authorization $token;
 {{- end -}}
 
 {{/*
+Define the X-Forwarded-User and X-Forwarded-Email headers to be set up for up stream systems.
+*/}}
+{{- define "bmrg.ingress.config.auth_proxy_user_email" -}}
+auth_request_set $user   $upstream_http_x_auth_request_user;
+auth_request_set $email  $upstream_http_x_auth_request_email;
+proxy_set_header X-Forwarded-User  $user;
+proxy_set_header X-Forwarded-Email $email;
+{{- end -}}
+
+{{/*
 Get the http_origin from the values host, should return boomerangplatform.net
 */}}
 {{- define "bmrg.host.suffix" -}}


### PR DESCRIPTION
Introduced a new utility method to set the X-Forwarded-User and X-Forwarded-Email headers

Closes #

Helps with the bmrg-flow chart to allow GitHub integration. 

#### Changelog

**New**

- utility called `bmrg.ingress.config.auth_proxy_user_email` 

**Changed**

- NA

**Removed**

- NA

#### Testing / Reviewing


