### PR TITLE
Map username and email headers in the ingress for github provider

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.9.2
+version: 4.9.3
 appVersion: 3.4.0
 home: https://useboomerang.io
 dependencies:
   - name: bmrg-common
     repository: https://raw.githubusercontent.com/boomerang-io/charts/index
-    version: 3.0.1
+    version: 3.0.2
     alias: ch
 keywords:
 - boomerang

--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.9.3
+version: 4.9.4
 appVersion: 3.4.0
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-flow/templates/ingress-app.yaml
+++ b/bmrg-flow/templates/ingress-app.yaml
@@ -18,6 +18,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/configuration-snippet: |
       {{- include "bmrg.ingress.config.auth_proxy_access_control" $ | nindent 6 }}
       {{- include "bmrg.ingress.config.auth_proxy_authorization" $ | nindent 6 }}
+      {{- include "bmrg.ingress.config.auth_proxy_user_email" $ | nindent 6 }}
     {{- end }}
     {{ $.Values.global.ingress.annotationsPrefix}}/ssl-redirect: "true"
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
@@ -26,7 +27,7 @@ spec:
   rules:
     - host: {{ $.Values.global.ingress.host }}
       http:
-        paths:    
+        paths:
           - path: {{ default "" $.Values.global.ingress.root }}/{{ $tier }}/{{ $k }}
             backend:
               serviceName: {{ include "bmrg.name" (dict "context" $context "tier" $tier "component" $k ) }}

--- a/bmrg-flow/templates/ingress-service.yaml
+++ b/bmrg-flow/templates/ingress-service.yaml
@@ -23,6 +23,7 @@ metadata:
       {{- if $.Values.global.auth.enabled }}
       {{- include "bmrg.ingress.config.auth_proxy_access_control" $ | nindent 6 }}
       {{- include "bmrg.ingress.config.auth_proxy_authorization" $ | nindent 6 }}
+      {{- include "bmrg.ingress.config.auth_proxy_user_email" $ | nindent 6 }}
       {{- end }}
       if ($request_method = 'OPTIONS') {
       add_header 'Access-Control-Allow-Origin' $http_origin;


### PR DESCRIPTION
Closes # 

Using flow in standalone configuration with github auth provider doesn't received the JWT back in the security lib since github doesn't have one.

#### Changelog

**New**

- Mapped the two headers X-Forwarded-User and X-Forwarded-Email to flow down the stream. 

**Changed**

- NA

**Removed**

- NA

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
