### PR TITLE
Fix on using the appVersion

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.9.2
+version: 4.9.3
 appVersion: 3.4.0
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-flow/templates/configmap.yaml
+++ b/bmrg-flow/templates/configmap.yaml
@@ -43,7 +43,7 @@ data:
     boomerang.environment={{ .Release.Namespace }}
     boomerang.instance={{ .Release.Name }}
     boomerang.product={{ $.Values.general.namePrefix }}
-    boomerang.version={{ $.Chart.appVersion }}
+    boomerang.version={{ .Chart.AppVersion }}
     boomerang.otc=${FLOW_OTC}
     boomerang.authorization.basic.password=coronet-cottage-nave-idiom-resume
     boomerang.signOutUrl={{ $.Values.global.auth.prefix }}/sign_out{{ if $.Values.global.auth.signOutRedirect }}?rd={{ $.Values.global.auth.signOutRedirect }}{{ end }}


### PR DESCRIPTION
Picking-up the correct appVersion from Chart.yaml file

Closes #

When deploying the charts it failed with: 

`helm.go:81: [debug] template: bmrg-flow/templates/deployment-service.yaml:14:24: executing "bmrg-flow/templates/deployment-service.yaml" at <include (print $.Template.BasePath "/configmap.yaml") $>: error calling include: template: bmrg-flow/templates/configmap.yaml:46:26: executing "bmrg-flow/templates/configmap.yaml" at <$.Chart.appVersion>: can't evaluate field appVersion in type interface {}`

It looks like we need to use the `{{ .Chart.AppVersion }}` format for it to work.

#### Changelog

**New**

- NA

**Changed**

- configmap, how to reference the appVersion

**Removed**

- NA

#### Testing / Reviewing

In the standalone2 environment.
