### PR TITLE
Extending the resource configuration to bmrg-flow

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.9.4
+version: 4.9.6
 appVersion: 3.4.0
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-flow/templates/deployment-app.yaml
+++ b/bmrg-flow/templates/deployment-app.yaml
@@ -65,9 +65,7 @@ spec:
             periodSeconds: 60
             successThreshold: 1
             timeoutSeconds: 5
-          resources:
-            requests:
-              memory: 100Mi
+          {{- include "bmrg.resources.chart" (dict "context" $.Values "item" $v "tier" $tier ) | nindent 10 }}
       {{- if $values.image.pullSecret }}
       imagePullSecrets:
       - name: {{ $values.image.pullSecret }}

--- a/bmrg-flow/templates/deployment-service.yaml
+++ b/bmrg-flow/templates/deployment-service.yaml
@@ -87,9 +87,7 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
-          resources:
-            requests:
-              memory: 1Gi
+          {{- include "bmrg.resources.chart" (dict "context" $.Values "item" $v "tier" $tier ) | nindent 10 }}
           volumeMounts:
           - name: application-config
             mountPath: "/data"

--- a/bmrg-flow/values.yaml
+++ b/bmrg-flow/values.yaml
@@ -69,6 +69,9 @@ apps:
     service:
       type: ClusterIP
     zone: untrusted
+    resources:
+      requests:
+        memory: "100Mi"
 
 # Micro Service Configuration
 # Note: There are if conditions in the template referencing the service name i.e. urbancode
@@ -82,6 +85,9 @@ services:
       type: ClusterIP
     serviceAccount: null
     zone: semi-trusted
+    resources:
+      requests:
+        memory: "1Gi"
   listener:
     image:
       repository: /flow-service-listener
@@ -98,6 +104,9 @@ services:
     service:
       type: ClusterIP
     zone: untrusted
+    resources:
+      requests:
+        memory: "1Gi"
 
 # Global configuration. This can be overriden by a parent chart.
 global:


### PR DESCRIPTION
Closes #

Re-used the method defined in bmrg-common that allows to define and configure the resource definitions in values.yaml
The default remained the same, only that now are not hard coded in the deployment but rather extensible through the values.yaml

For the local installation we can run them (the 2 BE services: Controller and Workflow) with just 128Mi - tested on my laptop

#### Changelog

**New**

- NA

**Changed**

- Extended the configuration of the resource consumpion

**Removed**

- NA

#### Testing / Reviewing

Tested on my local environment, with both scenarios:
1/ without any value in the values.yaml it defaults to the previous set values (1GB for the 2 BE services and 100Mi for the front-end one)
2/ installing it with the `flow-basic-auth-values.yaml` is updating the resources definition to the values defined custom.

