### PR TITLE
Update Helm Chart for eventing-related properties

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.11.1
+version: 4.11.2
 appVersion: 3.5.0
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-flow/README.md
+++ b/bmrg-flow/README.md
@@ -18,13 +18,14 @@ For more information on the dependencies please see the Application Architecture
 
 ### Worker RBAC
 
-The worker priviledged RBAC is dependent on the Pod Security Policy and Cluster Role resources;
- - Pod Security Policy `ibm-privileged-psp`, and
- - Cluster Role `ibm-privileged-clusterrole`
+The worker privileged RBAC is dependent on the Pod Security Policy and Cluster Role resources;
 
-If you allow priviledge access by default then you can disable the creation of this service account by removing the value in the value yaml under `workers.rbac.role`
+- Pod Security Policy `ibm-privileged-psp`, and
+- Cluster Role `ibm-privileged-clusterrole`
 
-You can change the value to a Cluster Role that has priviledged access.
+If you allow privileged access by default then you can disable the creation of this service account by removing the value in the value yaml under `workers.rbac.role`
+
+You can change the value to a Cluster Role that has privileged access.
 
 ## Configuration
 
@@ -37,25 +38,26 @@ The following table lists the configurable parameters of the chart and their def
 | `general.namePrefix` | The name prefix used in the naming of all Kubernetes objects  | `$.Chart.Name` |
 | `general.enable.apidocs` | Enable the API Docs endpoint on the services to be picked up by the API Docs | `false` |
 | `general.enable.debug` | Enables additional logging and port forwarding advice on installation | `false` |
-| `general.enable.eventing` | Enables eventing as part of the installation. This will install the listener service to accept incoming webhooks and events. Optionally requires NATS | `true` |
 
 ### Task Worker Configuration
 
 | Parameter | Description | Default Value |
 |---|---|---|
-| `workers.rbac.role` | The kubernetes service account name that allows priviledged access. | `ibm-privileged-clusterrole` |
+| `workers.rbac.role` | The kubernetes service account name that allows privileged access. | `ibm-privileged-clusterrole` |
 | `workers.logging.type` | The logging implementation to use. Default is kubernetes log api. Available Options: `default` and `loki` | `default` |
 | `workers.logging.host` | The elasticsearch host service name. _Only required if type is 'loki'_ | <ul><li>default:</li><li>loki: `loki.svc.cluster.local`</li></ul> |
 | `workers.logging.port` | The elasticsearch port. _Only required if type is 'loki'_ | <ul><li>default:</li><li>loki: `3100`</li></ul> |
 | `workers.logging.secrets` | The elastic logging certs secret. | <ul><li>default:</li><li>loki:</li></ul> |
 | `workers.enable.deletion` | Will delete any workers that are completed and in non error state. | `true` |
-| `workers.enable.dedicatedNodes` | Runs the Flow wokers to run on specific nodes with the taint `dedicated=bmrg-worker:NoSchedule` and also a label of `node-role.kubernetes.io/bmrg-worker=true` | `false` |
+| `workers.enable.dedicatedNodes` | Runs the Flow workers to run on specific nodes with the taint `dedicated=bmrg-worker:NoSchedule` and also a label of `node-role.kubernetes.io/bmrg-worker=true` | `false` |
 
 *Note:*
-1. If you choose `loki` make sure to adjust your retention period. https://www.ibm.com/support/knowledgecenter/en/SSBS6K_3.1.1/manage_metrics/log_change_retention.html
+
+1. If you choose `loki` make sure to adjust your retention period. <https://www.ibm.com/support/knowledgecenter/en/SSBS6K_3.1.1/manage_metrics/log_change_retention.html>
 2. If you choose `default` be aware of the kubernetes log rotation and storage requirements.
 
 *References:*
+
 - [Kubernetes Taints and Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
 - [Kubernetes Node Selection](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
 
@@ -124,13 +126,12 @@ The following table lists the configurable parameters of the chart and their def
 | `mongodb.password` | Database user password | `passw0rd` |
 | `database.mongodb.secretName` | The secret to get the password from. | |
 
-### NATS Configuration
+### Eventing Configuration
 
 | Parameter | Description | Default Value |
 |---|---|---|
-| `nats.enable` | Enable NATS | `true` |
-| `nats.url` | The NATS Url | `nats://bmrg-nats:4222` |
-| `nats.cluster` | NATS Streaming Cluster | `bmrg-stan` |
+| `eventing.enables` | Enables eventing as part of the installation. This will install the listener service to accept incoming webhooks and events. Optionally requires NATS | `true` |
+| `eventing.natsUrls` | A list of comma separated NATS server URLs | `nats://bmrg-dev-nats:4222` |
 
 ### Tekton Configuration
 

--- a/bmrg-flow/README.md
+++ b/bmrg-flow/README.md
@@ -130,7 +130,7 @@ The following table lists the configurable parameters of the chart and their def
 
 | Parameter | Description | Default Value |
 |---|---|---|
-| `eventing.enables` | Enables eventing as part of the installation. This will install the listener service to accept incoming webhooks and events. Optionally requires NATS | `true` |
+| `eventing.enabled` | Enables eventing as part of the installation. This will install the listener service to accept incoming webhooks and events. Optionally requires NATS | `true` |
 | `eventing.natsUrls` | A list of comma separated NATS server URLs | `nats://bmrg-dev-nats:4222` |
 
 ### Tekton Configuration

--- a/bmrg-flow/templates/configmap.yaml
+++ b/bmrg-flow/templates/configmap.yaml
@@ -22,15 +22,16 @@ data:
     {{ $k }}.service.root={{ if $.Values.global.ingress.root }}{{ $.Values.global.ingress.root }}{{ end }}/services/{{ $k }}
     {{- end }}
     {{- include "bmrg.core.services" $ | indent 4 }}
-    eventing.enabled={{ $values.general.enable.eventing }}
-    eventing.jetstream.enabled={{ $values.jetstream.enabled }}
-    {{- if $.Values.jetstream.enabled }}
-    eventing.jetstream.server.url={{ $values.jetstream.url }}
+    eventing.enabled={{ $values.eventing.enabled }}
+    {{- if $.Values.eventing.enabled }}
+    eventing.nats.server.urls={{ $values.eventing.natsUrls }}
+    eventing.nats.server.reconnect-wait-time=PT10S
+    eventing.nats.server.reconnect-max-attempts=-1
     eventing.jetstream.stream.name={{ .Release.Name }}-event-stream
-    eventing.jetstream.stream.subject={{ .Release.Name }}-event-stream
-    eventing.jetstream.consumer.push.name={{ .Release.Name }}-event-push-consumer
-    eventing.jetstream.consumer.push.delivery-subject=out.flow.event
-    eventing.jetstream.consumer.pull.name={{ .Release.Name }}-event-pull-consumer
+    eventing.jetstream.stream.storage-type=File
+    eventing.jetstream.stream.subject={{ .Release.Name }}.event.cloudevent
+    eventing.jetstream.consumer.name={{ .Release.Name }}-event-consumer
+    eventing.jetstream.consumer.resub-wait-time=PT10S
     {{- end }}
     {{- if $.Values.general.enable.debug }}
     logging.level.org.springframework.web.client.RestTemplate=DEBUG

--- a/bmrg-flow/templates/configmap.yaml
+++ b/bmrg-flow/templates/configmap.yaml
@@ -24,8 +24,13 @@ data:
     {{- include "bmrg.core.services" $ | indent 4 }}
     eventing.enabled={{ $values.general.enable.eventing }}
     eventing.jetstream.enabled={{ $values.jetstream.enabled }}
-    {{- if $.Values.jetstream.enable }}
+    {{- if $.Values.jetstream.enabled }}
     eventing.jetstream.server.url={{ $values.jetstream.url }}
+    eventing.jetstream.stream.name={{ .Release.Name }}-event-stream
+    eventing.jetstream.stream.subject={{ .Release.Name }}-event-stream
+    eventing.jetstream.consumer.push.name={{ .Release.Name }}-event-push-consumer
+    eventing.jetstream.consumer.push.delivery-subject=out.flow.event
+    eventing.jetstream.consumer.pull.name={{ .Release.Name }}-event-pull-consumer
     {{- end }}
     {{- if $.Values.general.enable.debug }}
     logging.level.org.springframework.web.client.RestTemplate=DEBUG

--- a/bmrg-flow/templates/ingress-service-listener.yaml
+++ b/bmrg-flow/templates/ingress-service-listener.yaml
@@ -4,7 +4,7 @@
 {{- $k := "listener" -}}
 {{- $values := .Values -}}
 {{- $context := . -}}
-{{- if and $.Values.global.ingress.enabled $values.general.enable.eventing -}}
+{{- if and $.Values.global.ingress.enabled $values.eventing.enabled -}}
 {{- $apiV1 := false -}}
 {{- $apiVersion := "extensions/v1beta1" -}}
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}

--- a/bmrg-flow/values.yaml
+++ b/bmrg-flow/values.yaml
@@ -8,7 +8,6 @@ general:
   enable:
     apidocs: false
     debug: false
-    eventing: true
   externalUrl:
     teams:
     users:
@@ -163,9 +162,10 @@ monitoring:
       host: jaeger-dev-agent
       port: 5778
 
-jetstream:
-  enabled: false
-  url: nats://localhost:4222
+# Eventing related values
+eventing:
+  enabled: true
+  natsUrls: nats://bmrg-dev-nats:4222
 
 tekton:
   enabled: true

--- a/bmrg-flow/values.yaml
+++ b/bmrg-flow/values.yaml
@@ -164,7 +164,7 @@ monitoring:
 
 # Eventing related values
 eventing:
-  enabled: true
+  enabled: false
   natsUrls: nats://bmrg-dev-nats:4222
 
 tekton:


### PR DESCRIPTION
Add missing values for latest `lib.eventing` (version `0.2.2`) and NATS Jetstream.

#### Changelog

**Changed**

- Updated `configmap` to use new values from `values.yaml`.
