### PR TITLE
Feat ingress class name

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.12.12
+version: 4.12.13
 appVersion: 3.8.0
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.12.13
+version: 4.12.14
 appVersion: 3.8.0
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-flow/templates/ingress-app.yaml
+++ b/bmrg-flow/templates/ingress-app.yaml
@@ -35,6 +35,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
     kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
 spec:
+  ingressClassName: {{ $.Values.global.ingress.class}}
   rules:
     - host: {{ $.Values.global.ingress.host }}
       http:

--- a/bmrg-flow/templates/ingress-service-api.yaml
+++ b/bmrg-flow/templates/ingress-service-api.yaml
@@ -25,6 +25,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/limit-connections: "3"
     kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
 spec:
+  ingressClassName: {{ $.Values.global.ingress.class}}
   rules:
     - host: {{ $.Values.global.ingress.host }}
       http:

--- a/bmrg-flow/templates/ingress-service-listener.yaml
+++ b/bmrg-flow/templates/ingress-service-listener.yaml
@@ -27,6 +27,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/limit-connections: "3"
     kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
 spec:
+  ingressClassName: {{ $.Values.global.ingress.class}}
   rules:
     - host: {{ $.Values.global.ingress.host }}
       http:

--- a/bmrg-flow/templates/ingress-service.yaml
+++ b/bmrg-flow/templates/ingress-service.yaml
@@ -47,6 +47,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
     kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
 spec:
+  ingressClassName: {{ $.Values.global.ingress.class}}
   rules:
     - host: {{ $.Values.global.ingress.host }}
       http:

--- a/bmrg-flow/values.yaml
+++ b/bmrg-flow/values.yaml
@@ -116,11 +116,10 @@ global:
     root: /flow
     host: cloud.boomerangplatform.net
     tlsSecretName: bmrg-tls-cloud
-    # The prefix for the annotations inside the ingress definition. Typically for IKS Community Ingress
-    # you need to set it to "nginx.ingress.kubernetes.io"
-    annotationsPrefix: "ingress.kubernetes.io"
+    # The prefix for the annotations inside the ingress definition.
+    annotationsPrefix: "nginx.ingress.kubernetes.io"
     # The class of the ingress, it is used to mark the ingress resources to be picked-up by a specific
-    # controller. For IKS Community Ingress set it to "public-iks-k8s-nginx"
+    # controller.
     class: "nginx"
     # Enable appRoot if you wish the 'app-root' i.e. '/' ingress annotation to redirect to the flow app
     enableAppRoot: false


### PR DESCRIPTION
Closes #64

Updates Ingress definitions for latest spec

#### Changelog

**New**

- Added `ingressClassName`

**Changed**

- Values.global.ingress.annotationsPrefix

**Removed**

- {{removed thing}}

#### Testing / Reviewing

Tested in AKS 1.22 with Ingress Controller 1.2
