### PR TITLE
Removed ingress.class annotation and added use-regex

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.12.15
-appVersion: 3.9.0
+version: 4.13.0
+appVersion: 3.10.0
 home: https://useboomerang.io
 dependencies:
   - name: bmrg-common

--- a/bmrg-flow/README.md
+++ b/bmrg-flow/README.md
@@ -8,7 +8,7 @@ Boomerang Flow is a modern cloud native workflow automation tool built on top of
 
 ## Dependencies
 
-- Kubernetes 1.13+
+- Kubernetes 1.20+
 - MongoDB \
 - NGINX Ingress Controller 0.22+
 - Helm v3

--- a/bmrg-flow/templates/ingress-service-api.yaml
+++ b/bmrg-flow/templates/ingress-service-api.yaml
@@ -23,7 +23,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
     {{ $.Values.global.ingress.annotationsPrefix}}/limit-rpm: "100"
     {{ $.Values.global.ingress.annotationsPrefix}}/limit-connections: "3"
-    kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
+    {{ $.Values.global.ingress.annotationsPrefix}}/use-regex: "true"
 spec:
   ingressClassName: {{ $.Values.global.ingress.class}}
   rules:

--- a/bmrg-flow/templates/ingress-service-listener.yaml
+++ b/bmrg-flow/templates/ingress-service-listener.yaml
@@ -25,7 +25,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
     {{ $.Values.global.ingress.annotationsPrefix}}/limit-rpm: "100"
     {{ $.Values.global.ingress.annotationsPrefix}}/limit-connections: "3"
-    kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
+    {{ $.Values.global.ingress.annotationsPrefix}}/use-regex: "true"
 spec:
   ingressClassName: {{ $.Values.global.ingress.class}}
   rules:

--- a/bmrg-flow/templates/ingress-service.yaml
+++ b/bmrg-flow/templates/ingress-service.yaml
@@ -45,7 +45,7 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/ssl-redirect: "false"
     {{ $.Values.global.ingress.annotationsPrefix}}/rewrite-target: /{{ $k }}/$2
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
-    kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
+    {{ $.Values.global.ingress.annotationsPrefix}}/use-regex: "true"
 spec:
   ingressClassName: {{ $.Values.global.ingress.class}}
   rules:


### PR DESCRIPTION
Removes the backwards compatibility as discussed with the previous NGINX / Ingress changes.

#### Changelog

**New**

- `use-regex` annotation

**Removed**

- `ingress.class` annotation
