### PR TITLE
removed ingress class annotations as the support for it was dropped

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-flow
 description: Boomerang Flow
 type: application
-version: 4.13.3
+version: 4.13.4
 appVersion: 3.10.0
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-flow/templates/ingress-app.yaml
+++ b/bmrg-flow/templates/ingress-app.yaml
@@ -20,7 +20,6 @@ metadata:
   labels:
     {{- include "bmrg.labels.chart" (dict "context" $context "tier" $tier "component" $k ) | nindent 4 }}
   annotations:
-  annotations:
     {{- if eq $.Values.global.auth.enabled true }}
     {{- include "bmrg.ingress.config.auth_proxy_auth_annotations.global" $ | nindent 4 }}
     {{ $.Values.global.ingress.annotationsPrefix}}/configuration-snippet: |
@@ -33,7 +32,6 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/app-root: "{{ default "" $.Values.global.ingress.root }}/{{ $tier }}/{{ $k }}"
     {{- end }}
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
-    kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
 spec:
   ingressClassName: {{ $.Values.global.ingress.class}}
   rules:


### PR DESCRIPTION
Closes #

Fixes https://github.com/boomerang-io/roadmap/issues/358

#### Changelog

**New**

- N/A

**Changed**

- N/A

**Removed**

- Removed the `kubernetes.io/ingress.class` annotation since the support for it was dropped (reference - https://github.com/boomerang-io/roadmap/issues/358#issuecomment-1175702875)

#### Testing / Reviewing

Tested on a local Kubernetes deployment using `k3s` v1.21
