### PR TITLE
Get name prefix from release name

### DIFF
--- a/bmrg-common/Chart.yaml
+++ b/bmrg-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-common
 description: Common helpers for Boomerang charts
 type: library
-version: 3.0.3
+version: 3.0.4
 home: https://useboomerang.io
 keywords:
 - boomerang

--- a/bmrg-common/templates/_boomerang.tpl
+++ b/bmrg-common/templates/_boomerang.tpl
@@ -49,7 +49,7 @@ We truncate at 40 chars because some Kubernetes name fields are limited to 63 (b
 Example Usage: {{- include "bmrg.name" (dict "context" $ "tier" $tier "component" $k ) }}
 */}}
 {{- define "bmrg.name.prefix" -}}
-{{- default .Chart.Name .Values.general.namePrefix | trunc 40 | trimSuffix "-" -}}
+{{- default .Release.Name .Values.general.namePrefix | trunc 40 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bmrg-common/templates/_boomerang.tpl
+++ b/bmrg-common/templates/_boomerang.tpl
@@ -144,17 +144,16 @@ Get the http_origin from the values host, should return boomerangplatform.net
 */}}
 {{- define "bmrg.host.suffix" -}}
 {{- $host := "" -}}
-{{- if hasKey $.Values.global.ingress "host" }}
-{{- $host := $.Values.global.ingress.host -}}
-{{- else if hasKey $.Values.ingress "host" -}}
-{{- $host := $.Values.ingress.host -}}
+{{- if ((($.Values).global).ingress).host }}
+{{- $host = $.Values.global.ingress.host -}}
+{{- else if (($.Values).ingress).host -}}
+{{- $host = $.Values.ingress.host -}}
 {{- end -}}
 {{- if $host -}}
 {{- $parts := splitList "." $host -}}
 {{- $nElement := last $parts -}}
 {{- $firstElements := initial $parts -}}
 {{- $nMinusOneElement := last $firstElements -}}
-
 {{ printf "%s\\.%s" $nMinusOneElement $nElement }}
 {{- else -}}
 {{ printf "*" }}


### PR DESCRIPTION
Closes #

The templates that are using the `bmrg.name.prefix` helper function should have the value based on the name of the release in order to be consistent with other Kubernetes objects.

#### Changelog

**New**

- N/A

**Changed**

- Changed the `bmrg.name.prefix` template function to return the `.Release.Name` value instead of `.Chart.Name` when the `name.prefix` is empty or nil.
- Fixed some errors when executing the `bmrg.host.suffix` helper function:
   - `error calling include: template: ess-core/charts/bmrg-common/templates/_boomerang.tpl:147:15: executing "bmrg.host.suffix" at <$.Values.global.ingress>: nil pointer evaluating interface {}.ingress`
   - `host` variable always returned empty because it was declared again instead of having an assignment

**Removed**

- N/A

#### Testing / Reviewing

Tested using `helm install` with `dry-run`
