### PR TITLE
remove annoation which falied on helm install

### DIFF
--- a/bmrg-bosun/Chart.yaml
+++ b/bmrg-bosun/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bmrg-bosun
 description: Boomerang Bosun
 type: application
-version: 2.3.5
+version: 2.3.6
 appVersion: "1.0.2"
 home: https://useboomerang.io
 dependencies:

--- a/bmrg-bosun/templates/ingress-app.yaml
+++ b/bmrg-bosun/templates/ingress-app.yaml
@@ -29,7 +29,6 @@ metadata:
     {{- end }}
     {{ $.Values.global.ingress.annotationsPrefix}}/ssl-redirect: "true"
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
-    kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
 spec:
   ingressClassName: {{ $.Values.global.ingress.class}}
   rules:

--- a/bmrg-bosun/templates/ingress-service.yaml
+++ b/bmrg-bosun/templates/ingress-service.yaml
@@ -40,7 +40,6 @@ metadata:
     {{ $.Values.global.ingress.annotationsPrefix}}/ssl-redirect: "false"
     {{ $.Values.global.ingress.annotationsPrefix}}/rewrite-target: /{{ $k }}/$2
     {{ $.Values.global.ingress.annotationsPrefix}}/client-max-body-size: 1m
-    kubernetes.io/ingress.class: {{ $.Values.global.ingress.class}}
 spec:
   ingressClassName: {{ $.Values.global.ingress.class}}
   rules:


### PR DESCRIPTION
remove `kubernetes.io/ingress.class`. it is conflict with `ingressClassName` which cause helm install falied
`Error: INSTALLATION FAILED: Ingress.extensions "bmrg-bosun-services-policy" is invalid: [annotations.kubernetes.io/ingress.class](http://annotations.kubernetes.io/ingress.class): Invalid value: "nginx": can not be set when the class field is also set`
